### PR TITLE
fix: Tab menu apply overFlow on session page

### DIFF
--- a/src/components/backend-ai-session-view.ts
+++ b/src/components/backend-ai-session-view.ts
@@ -491,7 +491,7 @@ export default class BackendAISessionView extends BackendAIPage {
         <div slot="message">
           <h3 class="tab horizontal center layout" style="margin-top:0;margin-bottom:0;">
             <div class="scroll hide-scrollbar">
-              <div class="horizontal layout flex start-justified" style="width:70%;">
+              <div class="horizontal layout flex start-justified" style="overFlow:auto;">
                 <mwc-tab-bar>
                   <mwc-tab title="running" label="${_t('session.Running')}" @click="${(e) => this._showTab(e.target)}"></mwc-tab>
                   <mwc-tab title="interactive" label="${_t('session.Interactive')}" @click="${(e) => this._showTab(e.target)}"></mwc-tab>


### PR DESCRIPTION
This PR resolves issue https://github.com/lablup/backend.ai-webui-ossca-2023/issues/2 in this repo.

Even if session page size is reduced, Tab menus can be clicked

 
![스크린샷 2023-07-25 00-30-27](https://github.com/lablup/backend.ai-webui-ossca-2023/assets/28584221/e5980b2e-0618-4ef1-9c9b-18c8c426fe63)
Before pr

![스크린샷 2023-07-25 00-59-26](https://github.com/lablup/backend.ai-webui-ossca-2023/assets/28584221/9f0358db-4334-4edf-9858-314e9946f536)
After pr