### PR TITLE
refactor: modify client config constructor type check in backend.ai-client-esm.ts

### DIFF
--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -43,7 +43,7 @@ class ClientConfig {
    * @param {string} endpoint  - endpoint of Backend.AI manager
    * @param {string} connectionMode - connection mode. 'API', 'SESSION' is supported. `SESSION` mode requires webserver.
    */
-  constructor(accessKey: string, secretKey: string, endpoint: string, connectionMode: string = 'API') {
+  constructor(accessKey?: string, secretKey?: string, endpoint?: string, connectionMode: string = 'API') {
     // default configs.
     this._apiVersionMajor = '4';
     this._apiVersion = 'v4.20190615'; // For compatibility with 19.03 / 1.4. WILL BE DEPRECATED AND UPGRADED TO v6 FROM 23.03.
@@ -136,9 +136,9 @@ class ClientConfig {
    */
   static createFromEnv() {
     return new this(
-      process.env.BACKEND_ACCESS_KEY ?? '',
-      process.env.BACKEND_SECRET_KEY ?? '',
-      process.env.BACKEND_ENDPOINT ?? ''
+      process.env.BACKEND_ACCESS_KEY,
+      process.env.BACKEND_SECRET_KEY,
+      process.env.BACKEND_ENDPOINT
     );
   }
 }


### PR DESCRIPTION
Creating a ClientConfig instance requires arguments as a string and createFromEnv() is currently using the "?? operator" to set a default empty string ('').

I believe it would be more appropriate to use the "?: operator" to allow for undefined arguments. This is because ClientConfig already includes an "if-else" statement to check if a required key is undefined or null and dynamically create configurations.

If there's a better alternative, I would appreciate your feedback. 

Thank you.